### PR TITLE
Changed encoding to UTF-8 as per requirement

### DIFF
--- a/SignatureHandler.cs
+++ b/SignatureHandler.cs
@@ -31,7 +31,7 @@ public class SignatureHandler : ISignatureHandler
     public string Sign(IDynamicObject parameters)
     {
         var options = string.Join(ISignatureHandler.ItemsDelimiter, GetParamsToSign(parameters.Dictionary(), _ignoredKeys));
-        var encoding = new System.Text.ASCIIEncoding();
+        var encoding = new System.Text.UTF8Encoding();
         var hash = new HMACSHA512(encoding.GetBytes(_secretKey));
 
         return Convert.ToBase64String(hash.ComputeHash(encoding.GetBytes(options)));


### PR DESCRIPTION
As per requirements stated in [Signature generation and verification](https://developers.ecommpay.com/en/en_PP_Authentication.html) updated encoding from ASCII to UTF-8. 
This fixes issue with having diacritics in any of parameters needed for opening payment page.